### PR TITLE
chore: afterburner-sh org links + footer license fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,8 @@ authors = ["Theo Bulut <vertexclique@gmail.com>"]
 # Apache-2.0 four years after its release). Apache-2.0 crates (afterburner-afb,
 # burndb, burn/*) set `license = "Apache-2.0"` explicitly in their [package].
 license = "BUSL-1.1"
-repository = "https://github.com/vertexclique/afterburner"
-homepage = "https://github.com/vertexclique/afterburner"
+repository = "https://github.com/afterburner-sh/afterburner"
+homepage = "https://github.com/afterburner-sh/afterburner"
 documentation = "https://docs.rs/afterburner"
 # Every crate publishes with the top-level README (workspace-inherited;
 # cargo resolves this relative to the workspace root and bundles it).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://github.com/vertexclique/afterburner/raw/master/art/svg/afterburner-bg-2000x500.svg" alt="Afterburner" width="100%"/>
+  <img src="https://github.com/afterburner-sh/afterburner/raw/master/art/svg/afterburner-bg-2000x500.svg" alt="Afterburner" width="100%"/>
 </p>
 
 <p align="center">
@@ -80,7 +80,7 @@ BURN_VERSION=v0.1.2 curl -fsSL https://afterburner.sh | sh
 $env:BURN_VERSION = 'v0.1.2'; iwr -useb https://afterburner.sh | iex
 ```
 
-Or grab a tarball directly from the [Releases page](https://github.com/vertexclique/afterburner/releases). Archives are named `burn-<version>-<target>.tar.gz` (or `.zip` for Windows) and ship with a `.sha256` next to them.
+Or grab a tarball directly from the [Releases page](https://github.com/afterburner-sh/afterburner/releases). Archives are named `burn-<version>-<target>.tar.gz` (or `.zip` for Windows) and ship with a `.sha256` next to them.
 
 Built with `--features release-cli` (every backend, every L3 shadow, TypeScript loader), so it's a single self-contained binary. No runtime libsqlite3, libssl, or libclang required. Plugin `.wasm` is `include_bytes!`-baked into the binary at build time.
 

--- a/website/docs.html
+++ b/website/docs.html
@@ -865,7 +865,7 @@
     <div class="nav__cta">
       <a href="index.html" class="btn btn--ghost btn--sm">Home</a>
       <a href="https://nodejs.org/docs/latest-v26.x/api/" class="btn btn--ghost btn--sm">Node.js Docs</a>
-      <a href="https://github.com/vertexclique/afterburner" class="btn btn--primary btn--sm btn--burn">
+      <a href="https://github.com/afterburner-sh/afterburner" class="btn btn--primary btn--sm btn--burn">
         <video class="burn-bg" src="art/burning.mp4" muted loop playsinline preload="metadata"></video>
         <svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12c0 4.42 2.87 8.17 6.84 9.5.5.08.66-.23.66-.5v-1.69c-2.77.6-3.36-1.34-3.36-1.34-.46-1.16-1.11-1.47-1.11-1.47-.91-.62.07-.6.07-.6 1 .07 1.53 1.03 1.53 1.03.87 1.52 2.34 1.07 2.91.83.09-.65.35-1.09.63-1.34-2.22-.25-4.55-1.11-4.55-4.94 0-1.11.39-2 1.03-2.71-.1-.25-.45-1.29.1-2.64 0 0 .84-.27 2.75 1.02.79-.22 1.65-.33 2.5-.33.85 0 1.71.11 2.5.33 1.91-1.29 2.75-1.02 2.75-1.02.55 1.35.2 2.39.1 2.64.64.71 1.03 1.6 1.03 2.71 0 3.84-2.34 4.69-4.57 4.94.36.31.69.92.69 1.85V21c0 .27.16.59.67.5C19.14 20.16 22 16.42 22 12A10 10 0 0 0 12 2z"/></svg>
         <span class="btn-label">Star</span>
@@ -1221,7 +1221,7 @@ module.exports = () =&gt; ({ hits, seen });</pre>
     .<span class="tok-fn">cache_backend</span>(Arc::<span class="tok-fn">new</span>(RedisBackend { client }))
     .<span class="tok-fn">build</span>()?;</pre>
       </div>
-      <p>See <a href="https://github.com/vertexclique/afterburner/tree/master/examples/cache-backend-sqlite" style="color: var(--action);"><code>examples/cache-backend-sqlite</code></a> for a working SQLite-WAL coordinator that two <code>Afterburner</code> instances share scripts through.</p>
+      <p>See <a href="https://github.com/afterburner-sh/afterburner/tree/master/examples/cache-backend-sqlite" style="color: var(--action);"><code>examples/cache-backend-sqlite</code></a> for a working SQLite-WAL coordinator that two <code>Afterburner</code> instances share scripts through.</p>
 
       <h3 id="extend-host">HostContext</h3>
       <p>Custom callbacks scripts can reach via <code>require('afterburner:host')</code>. Useful for streaming UDFs (<code>emit_row</code>), structured logging (<code>log</code>), and reading host-resolved configuration (<code>get_env</code>) without granting raw <code>process.env</code> access.</p>
@@ -1344,7 +1344,7 @@ $ <span class="tok-mod">burn</span> -A runall.js                            <spa
       </table></div>
 
       <h2 id="node-compat"><span class="anchor">#</span>Node compat surface</h2>
-      <p>Afterburner targets the <strong>Node.js 26</strong> surface. <code>burn npm install</code> and <code>require('express')</code> from a real <code>node_modules</code> tree both work end-to-end — see <a href="https://github.com/vertexclique/afterburner/tree/master/examples/express-app" style="color: var(--action);"><code>examples/express-app</code></a>. Pure-JS modules are always available; host-backed ones are gated by the <code>Manifold</code>; surface-only entries load and expose the right shapes.</p>
+      <p>Afterburner targets the <strong>Node.js 26</strong> surface. <code>burn npm install</code> and <code>require('express')</code> from a real <code>node_modules</code> tree both work end-to-end — see <a href="https://github.com/afterburner-sh/afterburner/tree/master/examples/express-app" style="color: var(--action);"><code>examples/express-app</code></a>. Pure-JS modules are always available; host-backed ones are gated by the <code>Manifold</code>; surface-only entries load and expose the right shapes.</p>
 
       <div class="callout callout--ok">
         <div class="callout__icon">✓</div>
@@ -1508,7 +1508,7 @@ $ <span class="tok-mod">burn</span> -A runall.js                            <spa
           <span class="lang">shell</span>
           <button class="copy-btn">Copy</button>
         </div>
-<pre>$ <span class="tok-mod">git</span> clone https://github.com/vertexclique/afterburner
+<pre>$ <span class="tok-mod">git</span> clone https://github.com/afterburner-sh/afterburner
 $ <span class="tok-fn">cd</span> afterburner
 $ <span class="tok-mod">cargo</span> build --release --features bin
 $ ./target/release/<span class="tok-mod">burn</span> --version</pre>
@@ -1528,7 +1528,7 @@ $ ./target/release/<span class="tok-mod">burn</span> --version</pre>
           <div class="l">← Previous</div>
           <div class="t">Landing</div>
         </a>
-        <a class="pagefoot__btn" href="https://github.com/vertexclique/afterburner" style="text-align: right;">
+        <a class="pagefoot__btn" href="https://github.com/afterburner-sh/afterburner" style="text-align: right;">
           <div class="l">Next →</div>
           <div class="t">Examples on GitHub</div>
         </a>

--- a/website/index.html
+++ b/website/index.html
@@ -2495,7 +2495,7 @@
       </div>
       <div class="nav__cta">
         <a href="https://nodejs.org/docs/latest-v26.x/api/" class="btn btn--ghost btn--sm">Node.js Docs</a>
-        <a href="https://github.com/vertexclique/afterburner" class="btn btn--ghost btn--sm">GitHub</a>
+        <a href="https://github.com/afterburner-sh/afterburner" class="btn btn--ghost btn--sm">GitHub</a>
         <a href="docs.html" class="btn btn--primary btn--sm btn--burn">
           <video class="burn-bg" src="art/burning.mp4" muted loop playsinline preload="metadata"></video>
           <span class="btn-label">Get started →</span>
@@ -3043,7 +3043,7 @@
 
         <div class="bench__legend">
           <span><strong>rows / second / core</strong> &nbsp;·&nbsp; Intel Xeon W-2295, 18 cores, x86_64-linux</span>
-          <span>Source: <a href="https://github.com/vertexclique/afterburner">Afterburner</a> · published peer
+          <span>Source: <a href="https://github.com/afterburner-sh/afterburner">Afterburner</a> · published peer
             benchmarks</span>
         </div>
       </div>
@@ -3194,7 +3194,7 @@
         <div class="footer__col">
           <h4>Community</h4>
           <ul>
-            <li><a href="https://github.com/vertexclique/afterburner">GitHub</a></li>
+            <li><a href="https://github.com/afterburner-sh/afterburner">GitHub</a></li>
             <li><a href="https://crates.io/crates/afterburner">crates.io</a></li>
             <li><a href="https://registry.afterburner.sh">Package Registry</a></li>
             <li><a href="https://docs.rs/afterburner">docs.rs</a></li>
@@ -3203,8 +3203,8 @@
         </div>
       </div>
       <div class="footer__bottom">
-        <span>© 2026 vertexclique · Afterburner · Apache-2.0</span>
-        <span class="mono">vertexclique/afterburner</span>
+        <span>© 2026 Afterburner · BUSL-1.1</span>
+        <span class="mono">afterburner-sh/afterburner</span>
       </div>
     </div>
   </footer>

--- a/website/install.ps1
+++ b/website/install.ps1
@@ -11,7 +11,7 @@
 
 $ErrorActionPreference = 'Stop'
 
-$repo = 'vertexclique/afterburner'
+$repo = 'afterburner-sh/afterburner'
 $installDir = if ($env:BURN_INSTALL) { $env:BURN_INSTALL } else { Join-Path $env:USERPROFILE '.local\bin' }
 $version = if ($env:BURN_VERSION) { $env:BURN_VERSION } else { 'latest' }
 

--- a/website/install.sh
+++ b/website/install.sh
@@ -14,7 +14,7 @@
 
 set -eu
 
-repo="vertexclique/afterburner"
+repo="afterburner-sh/afterburner"
 install_dir="${BURN_INSTALL:-${HOME}/.local/bin}"
 
 die() {


### PR DESCRIPTION
Repo moved to the afterburner-sh org: flip all repository links, correct the footer license line (BUSL-1.1), bump install examples to v0.1.2.