### PR TITLE
chore: unify contact email and copyright holder

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -2,7 +2,7 @@
 
 This Contributor License Agreement ("Agreement") is adapted from the Apache
 Software Foundation Individual Contributor License Agreement. References to the
-"Apache Software Foundation" are replaced by **Psila.AI** ("the Licensor").
+"Apache Software Foundation" are replaced by **vertexclique** ("the Licensor").
 
 By submitting a Contribution to this project, You accept and agree to the
 following terms for Your present and future Contributions. Except for the

--- a/CLA.md
+++ b/CLA.md
@@ -72,4 +72,4 @@ KIND, either express or implied.
 Agreement is recorded electronically via the CLA Assistant bot on the GitHub
 repository the first time You open a pull request. Signing once covers all
 future Contributions to Licensor projects unless revoked in writing to
-licensing@afterburner.sh.
+info@afterburner.sh.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,4 +43,4 @@ New code goes in the appropriate crate's license tier:
 
 ## Reporting security issues
 
-Do not open public issues for vulnerabilities. Email **security@afterburner.sh**.
+Do not open public issues for vulnerabilities. Email **info@afterburner.sh**.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ to do so (see CLA.md §4).
 ## Licensing of contributions
 
 By contributing you agree your work is licensed under BSL 1.1 (converting to
-Apache-2.0 on the Change Date) and may also be offered by Psila.AI under
+Apache-2.0 on the Change Date) and may also be offered by vertexclique under
 commercial license terms, per the CLA. Do not add code under a license
 incompatible with this; disclose any third-party code and its license in the PR.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ exclude = ["examples"]
 version = "0.1.2"
 edition = "2024"
 rust-version = "1.90"
-authors = ["Theo Bulut <vertexclique@gmail.com>"]
+authors = ["Theo Bulut <info@afterburner.sh>"]
 # Engine crates are source-available under BSL 1.1 (each version converts to
 # Apache-2.0 four years after its release). Apache-2.0 crates (afterburner-afb,
 # burndb, burn/*) set `license = "Apache-2.0"` explicitly in their [package].

--- a/LICENSE
+++ b/LICENSE
@@ -7,10 +7,10 @@ License text copyright (c) 2017 MariaDB Corporation Ab, All Rights Reserved.
 
 Parameters
 
-Licensor:             Psila.AI
+Licensor:             vertexclique
 
 Licensed Work:        Afterburner
-                      The Licensed Work is (c) 2026 Psila.AI.
+                      The Licensed Work is (c) 2026 vertexclique.
 
 Additional Use Grant: You may make production use of the Licensed Work,
                       provided that such production use does not include,

--- a/LICENSE
+++ b/LICENSE
@@ -46,7 +46,7 @@ Additional Use Grant: You may make production use of the Licensed Work,
 
                       To obtain a commercial license for any use described
                       in (a), (b), or (c) above, contact
-                      licensing@afterburner.sh. See LICENSING.md.
+                      info@afterburner.sh. See LICENSING.md.
 
 Change Date:          Four years from the date the specific version of the
                       Licensed Work is first made publicly available. The
@@ -56,7 +56,7 @@ Change Date:          Four years from the date the specific version of the
 Change License:       Apache License, Version 2.0
 
 For information about alternative licensing arrangements for the Licensed Work,
-please contact licensing@afterburner.sh.
+please contact info@afterburner.sh.
 
 -----------------------------------------------------------------------------
 

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -46,7 +46,7 @@ source originates.
 
 ## How to obtain a commercial license
 
-Email **licensing@afterburner.sh** with:
+Email **info@afterburner.sh** with:
 
 - Your company / legal entity name.
 - Which of (1) host / (2) embed / (3) compete applies.

--- a/NOTICE
+++ b/NOTICE
@@ -1,7 +1,7 @@
 Afterburner
-Copyright (c) 2026 Psila.AI
+Copyright (c) 2026 vertexclique
 
-This product includes software developed by Psila.AI and contributors.
+This product includes software developed by vertexclique and contributors.
 
 The engine crates (afterburner, afterburner-core, afterburner-wasi,
 afterburner-ignite, afterburner-flow, afterburner-adaptive,
@@ -18,7 +18,7 @@ examples/ (see examples/LICENSE), and the afterburner-afb and burn/*
 packages — are licensed under Apache-2.0 via their own LICENSE /
 `license` metadata and are not subject to the Business Source License.
 
-"Afterburner", "burn", and related Marks are trademarks of Psila.AI. See
+"Afterburner", "burn", and related Marks are trademarks of vertexclique. See
 TRADEMARK.md. Use of the source code under the LICENSE does not grant any
 trademark rights.
 

--- a/NOTICE
+++ b/NOTICE
@@ -22,4 +22,4 @@ packages — are licensed under Apache-2.0 via their own LICENSE /
 TRADEMARK.md. Use of the source code under the LICENSE does not grant any
 trademark rights.
 
-For commercial licensing: licensing@afterburner.sh
+For commercial licensing: info@afterburner.sh

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Afterburner as a hosted/managed service, embedding it in a commercial product
 distributed to third parties (OEM), or using it to build a competing offering
 requires a commercial license — including via forks, rebrands, vendored, or
 embedded copies. See **[LICENSING.md](LICENSING.md)**; contact
-`licensing@afterburner.sh`.
+`info@afterburner.sh`.
 
 "Afterburner" and related marks are trademarks of Psila.AI; see
 [TRADEMARK.md](TRADEMARK.md). Contributions require a [CLA](CLA.md).

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ requires a commercial license — including via forks, rebrands, vendored, or
 embedded copies. See **[LICENSING.md](LICENSING.md)**; contact
 `info@afterburner.sh`.
 
-"Afterburner" and related marks are trademarks of Psila.AI; see
+"Afterburner" and related marks are trademarks of vertexclique; see
 [TRADEMARK.md](TRADEMARK.md). Contributions require a [CLA](CLA.md).
 
 ---

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -1,7 +1,7 @@
 # Trademark Policy
 
 "Afterburner", "burn", the Afterburner logo, and the `.burn` / `.afb` file
-extensions are trademarks of **Psila.AI** (the "Marks").
+extensions are trademarks of **vertexclique** (the "Marks").
 
 EU trademark application: **EUIPO No. TBD** (word mark "Afterburner", Nice
 classes 9 and 42; application to be filed — this reference is updated with the
@@ -36,4 +36,4 @@ Email **info@afterburner.sh** describing the intended use.
 
 Trademark rights are independent of, and survive, the BSL Change Date: even
 after a version's code converts to Apache-2.0 (four years after that version's
-release), the Marks remain owned by Psila.AI and this policy continues to apply.
+release), the Marks remain owned by vertexclique and this policy continues to apply.

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -32,7 +32,7 @@ trademark grant are separate.
 
 ## How to request permission
 
-Email **trademark@afterburner.sh** describing the intended use.
+Email **info@afterburner.sh** describing the intended use.
 
 Trademark rights are independent of, and survive, the BSL Change Date: even
 after a version's code converts to Apache-2.0 (four years after that version's

--- a/crates/afterburner-adaptive/src/adaptive.rs
+++ b/crates/afterburner-adaptive/src/adaptive.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-adaptive/src/lib.rs
+++ b/crates/afterburner-adaptive/src/lib.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-cloud/src/cache.rs
+++ b/crates/afterburner-cloud/src/cache.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-cloud/src/client.rs
+++ b/crates/afterburner-cloud/src/client.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-cloud/src/config.rs
+++ b/crates/afterburner-cloud/src/config.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-cloud/src/coord.rs
+++ b/crates/afterburner-cloud/src/coord.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-cloud/src/error.rs
+++ b/crates/afterburner-cloud/src/error.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-cloud/src/install.rs
+++ b/crates/afterburner-cloud/src/install.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-cloud/src/lib.rs
+++ b/crates/afterburner-cloud/src/lib.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-cloud/src/lock.rs
+++ b/crates/afterburner-cloud/src/lock.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-cloud/src/pkg.rs
+++ b/crates/afterburner-cloud/src/pkg.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-cloud/src/resolve.rs
+++ b/crates/afterburner-cloud/src/resolve.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-cloud/src/scaffold.rs
+++ b/crates/afterburner-cloud/src/scaffold.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-cloud/src/source.rs
+++ b/crates/afterburner-cloud/src/source.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-cloud/src/types.rs
+++ b/crates/afterburner-cloud/src/types.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-core/src/engine.rs
+++ b/crates/afterburner-core/src/engine.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-core/src/error.rs
+++ b/crates/afterburner-core/src/error.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-core/src/host.rs
+++ b/crates/afterburner-core/src/host.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-core/src/lib.rs
+++ b/crates/afterburner-core/src/lib.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-core/src/log.rs
+++ b/crates/afterburner-core/src/log.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-core/src/manifold.rs
+++ b/crates/afterburner-core/src/manifold.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-core/src/registry.rs
+++ b/crates/afterburner-core/src/registry.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-core/src/state_store.rs
+++ b/crates/afterburner-core/src/state_store.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-core/src/types.rs
+++ b/crates/afterburner-core/src/types.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-flow/src/chain.rs
+++ b/crates/afterburner-flow/src/chain.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-flow/src/engine.rs
+++ b/crates/afterburner-flow/src/engine.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-flow/src/lib.rs
+++ b/crates/afterburner-flow/src/lib.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-flow/tests/flow_engine.rs
+++ b/crates/afterburner-flow/tests/flow_engine.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-flow/tests/node_compat_e2e.rs
+++ b/crates/afterburner-flow/tests/node_compat_e2e.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-ignite/src/lib.rs
+++ b/crates/afterburner-ignite/src/lib.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-ignite/src/native_engine.rs
+++ b/crates/afterburner-ignite/src/native_engine.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-ignite/tests/node_compat_host.rs
+++ b/crates/afterburner-ignite/tests/node_compat_host.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-ignite/tests/perf_smoke.rs
+++ b/crates/afterburner-ignite/tests/perf_smoke.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-ignite/tests/script_mode.rs
+++ b/crates/afterburner-ignite/tests/script_mode.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-node-compat/build.rs
+++ b/crates/afterburner-node-compat/build.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-node-compat/src/active_manifold.rs
+++ b/crates/afterburner-node-compat/src/active_manifold.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-node-compat/src/bundle.rs
+++ b/crates/afterburner-node-compat/src/bundle.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-node-compat/src/child_process_host.rs
+++ b/crates/afterburner-node-compat/src/child_process_host.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-node-compat/src/crypto_host.rs
+++ b/crates/afterburner-node-compat/src/crypto_host.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-node-compat/src/dns_host.rs
+++ b/crates/afterburner-node-compat/src/dns_host.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-node-compat/src/fs_host.rs
+++ b/crates/afterburner-node-compat/src/fs_host.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-node-compat/src/hash_handles.rs
+++ b/crates/afterburner-node-compat/src/hash_handles.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-node-compat/src/host_context_active.rs
+++ b/crates/afterburner-node-compat/src/host_context_active.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-node-compat/src/http_host.rs
+++ b/crates/afterburner-node-compat/src/http_host.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-node-compat/src/lib.rs
+++ b/crates/afterburner-node-compat/src/lib.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-node-compat/src/native_install.rs
+++ b/crates/afterburner-node-compat/src/native_install.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-node-compat/src/os_host.rs
+++ b/crates/afterburner-node-compat/src/os_host.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-node-compat/src/prime_host.rs
+++ b/crates/afterburner-node-compat/src/prime_host.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-node-compat/src/shadows/argon2.rs
+++ b/crates/afterburner-node-compat/src/shadows/argon2.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-node-compat/src/shadows/bcrypt.rs
+++ b/crates/afterburner-node-compat/src/shadows/bcrypt.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-node-compat/src/shadows/jsonwebtoken.rs
+++ b/crates/afterburner-node-compat/src/shadows/jsonwebtoken.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-node-compat/src/shadows/mod.rs
+++ b/crates/afterburner-node-compat/src/shadows/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-node-compat/src/shadows/sharp.rs
+++ b/crates/afterburner-node-compat/src/shadows/sharp.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-node-compat/src/shadows/sqlite3.rs
+++ b/crates/afterburner-node-compat/src/shadows/sqlite3.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-node-compat/src/sign_handles.rs
+++ b/crates/afterburner-node-compat/src/sign_handles.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-node-compat/src/state_active.rs
+++ b/crates/afterburner-node-compat/src/state_active.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-node-compat/src/subtle_aes.rs
+++ b/crates/afterburner-node-compat/src/subtle_aes.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-node-compat/src/subtle_ec.rs
+++ b/crates/afterburner-node-compat/src/subtle_ec.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-node-compat/src/subtle_host.rs
+++ b/crates/afterburner-node-compat/src/subtle_host.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-node-compat/src/subtle_rsa.rs
+++ b/crates/afterburner-node-compat/src/subtle_rsa.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-node-compat/src/v8_host.rs
+++ b/crates/afterburner-node-compat/src/v8_host.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-node-compat/src/v8_serde.rs
+++ b/crates/afterburner-node-compat/src/v8_serde.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-node-compat/src/zlib_host.rs
+++ b/crates/afterburner-node-compat/src/zlib_host.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-plugin/src/envelope.rs
+++ b/crates/afterburner-plugin/src/envelope.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-plugin/src/globals/codec.rs
+++ b/crates/afterburner-plugin/src/globals/codec.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-plugin/src/globals/columnar.rs
+++ b/crates/afterburner-plugin/src/globals/columnar.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-plugin/src/globals/crypto.rs
+++ b/crates/afterburner-plugin/src/globals/crypto.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-plugin/src/globals/fs.rs
+++ b/crates/afterburner-plugin/src/globals/fs.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-plugin/src/globals/input.rs
+++ b/crates/afterburner-plugin/src/globals/input.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-plugin/src/globals/misc.rs
+++ b/crates/afterburner-plugin/src/globals/misc.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-plugin/src/globals/mod.rs
+++ b/crates/afterburner-plugin/src/globals/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-plugin/src/globals/output.rs
+++ b/crates/afterburner-plugin/src/globals/output.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-plugin/src/host_api.rs
+++ b/crates/afterburner-plugin/src/host_api.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-plugin/src/lib.rs
+++ b/crates/afterburner-plugin/src/lib.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-plugin/src/modes/columnar_invoke.rs
+++ b/crates/afterburner-plugin/src/modes/columnar_invoke.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-plugin/src/modes/compile.rs
+++ b/crates/afterburner-plugin/src/modes/compile.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-plugin/src/modes/compile_columnar.rs
+++ b/crates/afterburner-plugin/src/modes/compile_columnar.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-plugin/src/modes/compile_script.rs
+++ b/crates/afterburner-plugin/src/modes/compile_script.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-plugin/src/modes/daemon_event.rs
+++ b/crates/afterburner-plugin/src/modes/daemon_event.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-plugin/src/modes/daemon_init.rs
+++ b/crates/afterburner-plugin/src/modes/daemon_init.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-plugin/src/modes/invoke.rs
+++ b/crates/afterburner-plugin/src/modes/invoke.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-plugin/src/modes/legacy.rs
+++ b/crates/afterburner-plugin/src/modes/legacy.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-plugin/src/modes/mod.rs
+++ b/crates/afterburner-plugin/src/modes/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-plugin/src/modes/script.rs
+++ b/crates/afterburner-plugin/src/modes/script.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-plugin/src/stdio.rs
+++ b/crates/afterburner-plugin/src/stdio.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-thrust/src/admission.rs
+++ b/crates/afterburner-thrust/src/admission.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-thrust/src/lib.rs
+++ b/crates/afterburner-thrust/src/lib.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-thrust/src/numa.rs
+++ b/crates/afterburner-thrust/src/numa.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-thrust/tests/thrust_admission.rs
+++ b/crates/afterburner-thrust/tests/thrust_admission.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-thrust/tests/thrust_drain.rs
+++ b/crates/afterburner-thrust/tests/thrust_drain.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-thrust/tests/thrust_overloaded.rs
+++ b/crates/afterburner-thrust/tests/thrust_overloaded.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-thrust/tests/thrust_perf_smoke.rs
+++ b/crates/afterburner-thrust/tests/thrust_perf_smoke.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-thrust/tests/thrust_scale.rs
+++ b/crates/afterburner-thrust/tests/thrust_scale.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-thrust/tests/thrust_steal.rs
+++ b/crates/afterburner-thrust/tests/thrust_steal.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-wasi/build.rs
+++ b/crates/afterburner-wasi/build.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-wasi/src/capture.rs
+++ b/crates/afterburner-wasi/src/capture.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-wasi/src/chamber.rs
+++ b/crates/afterburner-wasi/src/chamber.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-wasi/src/columnar.rs
+++ b/crates/afterburner-wasi/src/columnar.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-wasi/src/daemon_cluster.rs
+++ b/crates/afterburner-wasi/src/daemon_cluster.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-wasi/src/daemon_dgram.rs
+++ b/crates/afterburner-wasi/src/daemon_dgram.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-wasi/src/daemon_envelopes.rs
+++ b/crates/afterburner-wasi/src/daemon_envelopes.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-wasi/src/daemon_http.rs
+++ b/crates/afterburner-wasi/src/daemon_http.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-wasi/src/daemon_http3.rs
+++ b/crates/afterburner-wasi/src/daemon_http3.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-wasi/src/daemon_http_outbound.rs
+++ b/crates/afterburner-wasi/src/daemon_http_outbound.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-wasi/src/daemon_inspector.rs
+++ b/crates/afterburner-wasi/src/daemon_inspector.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-wasi/src/daemon_net.rs
+++ b/crates/afterburner-wasi/src/daemon_net.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-wasi/src/daemon_port_claims.rs
+++ b/crates/afterburner-wasi/src/daemon_port_claims.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-wasi/src/daemon_runtime.rs
+++ b/crates/afterburner-wasi/src/daemon_runtime.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-wasi/src/daemon_sab.rs
+++ b/crates/afterburner-wasi/src/daemon_sab.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-wasi/src/daemon_shard_pool.rs
+++ b/crates/afterburner-wasi/src/daemon_shard_pool.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-wasi/src/daemon_tls.rs
+++ b/crates/afterburner-wasi/src/daemon_tls.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-wasi/src/daemon_workers.rs
+++ b/crates/afterburner-wasi/src/daemon_workers.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-wasi/src/host.rs
+++ b/crates/afterburner-wasi/src/host.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-wasi/src/host_imports.rs
+++ b/crates/afterburner-wasi/src/host_imports.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-wasi/src/intake.rs
+++ b/crates/afterburner-wasi/src/intake.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-wasi/src/lib.rs
+++ b/crates/afterburner-wasi/src/lib.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-wasi/src/manifold_codec.rs
+++ b/crates/afterburner-wasi/src/manifold_codec.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-wasi/src/nozzle.rs
+++ b/crates/afterburner-wasi/src/nozzle.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-wasi/src/test_support.rs
+++ b/crates/afterburner-wasi/src/test_support.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-wasi/src/wasm_engine.rs
+++ b/crates/afterburner-wasi/src/wasm_engine.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-wasi/src/wasm_loader.rs
+++ b/crates/afterburner-wasi/src/wasm_loader.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-wasi/tests/abi_parity.rs
+++ b/crates/afterburner-wasi/tests/abi_parity.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-wasi/tests/daemon_axum.rs
+++ b/crates/afterburner-wasi/tests/daemon_axum.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-wasi/tests/daemon_runtime.rs
+++ b/crates/afterburner-wasi/tests/daemon_runtime.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-wasi/tests/event_loop.rs
+++ b/crates/afterburner-wasi/tests/event_loop.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-wasi/tests/host_context.rs
+++ b/crates/afterburner-wasi/tests/host_context.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-wasi/tests/node_compat_host.rs
+++ b/crates/afterburner-wasi/tests/node_compat_host.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-wasi/tests/perf_smoke.rs
+++ b/crates/afterburner-wasi/tests/perf_smoke.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner-wasi/tests/sandbox_security.rs
+++ b/crates/afterburner-wasi/tests/sandbox_security.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/examples/input_framing_bench.rs
+++ b/crates/afterburner/examples/input_framing_bench.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/examples/output_framing_bench.rs
+++ b/crates/afterburner/examples/output_framing_bench.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/src/bin/burn.rs
+++ b/crates/afterburner/src/bin/burn.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/src/builder.rs
+++ b/crates/afterburner/src/builder.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/src/cli/args.rs
+++ b/crates/afterburner/src/cli/args.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/src/cli/banner.rs
+++ b/crates/afterburner/src/cli/banner.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/src/cli/bench.rs
+++ b/crates/afterburner/src/cli/bench.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/src/cli/build.rs
+++ b/crates/afterburner/src/cli/build.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/src/cli/check.rs
+++ b/crates/afterburner/src/cli/check.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/src/cli/daemon.rs
+++ b/crates/afterburner/src/cli/daemon.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/src/cli/manifold.rs
+++ b/crates/afterburner/src/cli/manifold.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/src/cli/mod.rs
+++ b/crates/afterburner/src/cli/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/src/cli/passthrough.rs
+++ b/crates/afterburner/src/cli/passthrough.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/src/cli/registry/mod.rs
+++ b/crates/afterburner/src/cli/registry/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/src/cli/registry/progress.rs
+++ b/crates/afterburner/src/cli/registry/progress.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/src/cli/repl.rs
+++ b/crates/afterburner/src/cli/repl.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/src/cli/run.rs
+++ b/crates/afterburner/src/cli/run.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/src/cli/script.rs
+++ b/crates/afterburner/src/cli/script.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/src/cli/shim.rs
+++ b/crates/afterburner/src/cli/shim.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/src/cli/style.rs
+++ b/crates/afterburner/src/cli/style.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/src/cli/thrust.rs
+++ b/crates/afterburner/src/cli/thrust.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/src/cli/version.rs
+++ b/crates/afterburner/src/cli/version.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/src/cli/worker.rs
+++ b/crates/afterburner/src/cli/worker.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/src/esm.rs
+++ b/crates/afterburner/src/esm.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/src/lib.rs
+++ b/crates/afterburner/src/lib.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/src/prelude.rs
+++ b/crates/afterburner/src/prelude.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/src/ts.rs
+++ b/crates/afterburner/src/ts.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b0_check.rs
+++ b/crates/afterburner/tests/b0_check.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b0_cli_vs_library.rs
+++ b/crates/afterburner/tests/b0_cli_vs_library.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b0_process_argv_env.rs
+++ b/crates/afterburner/tests/b0_process_argv_env.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b0_script_mode.rs
+++ b/crates/afterburner/tests/b0_script_mode.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b10_security.rs
+++ b/crates/afterburner/tests/b10_security.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b10_worker_threads.rs
+++ b/crates/afterburner/tests/b10_worker_threads.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b1_require_resolution.rs
+++ b/crates/afterburner/tests/b1_require_resolution.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b2_http_server.rs
+++ b/crates/afterburner/tests/b2_http_server.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b2b_multiplex.rs
+++ b/crates/afterburner/tests/b2b_multiplex.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b3_daemon_lifecycle.rs
+++ b/crates/afterburner/tests/b3_daemon_lifecycle.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b4_passthrough.rs
+++ b/crates/afterburner/tests/b4_passthrough.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b5_shim.rs
+++ b/crates/afterburner/tests/b5_shim.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b6_require_resolution.rs
+++ b/crates/afterburner/tests/b6_require_resolution.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b7_dgram.rs
+++ b/crates/afterburner/tests/b7_dgram.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b7_dns.rs
+++ b/crates/afterburner/tests/b7_dns.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b7_net.rs
+++ b/crates/afterburner/tests/b7_net.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b7_net_security.rs
+++ b/crates/afterburner/tests/b7_net_security.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b7_tls.rs
+++ b/crates/afterburner/tests/b7_tls.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b7_tls_security.rs
+++ b/crates/afterburner/tests/b7_tls_security.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b8_typescript.rs
+++ b/crates/afterburner/tests/b8_typescript.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b9_esm.rs
+++ b/crates/afterburner/tests/b9_esm.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_abort_signal_any.rs
+++ b/crates/afterburner/tests/b_abort_signal_any.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_async_hooks_await.rs
+++ b/crates/afterburner/tests/b_async_hooks_await.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_async_hooks_real.rs
+++ b/crates/afterburner/tests/b_async_hooks_real.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_async_iterator_global.rs
+++ b/crates/afterburner/tests/b_async_iterator_global.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_async_outbound_http.rs
+++ b/crates/afterburner/tests/b_async_outbound_http.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_atomics.rs
+++ b/crates/afterburner/tests/b_atomics.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_atomics_wait_async.rs
+++ b/crates/afterburner/tests/b_atomics_wait_async.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_atomics_wait_xprocess.rs
+++ b/crates/afterburner/tests/b_atomics_wait_xprocess.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_blob_url.rs
+++ b/crates/afterburner/tests/b_blob_url.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_buffer_extras.rs
+++ b/crates/afterburner/tests/b_buffer_extras.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_buffer_isutf8_test_mock.rs
+++ b/crates/afterburner/tests/b_buffer_isutf8_test_mock.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_builder_cwd.rs
+++ b/crates/afterburner/tests/b_builder_cwd.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_callsite_api.rs
+++ b/crates/afterburner/tests/b_callsite_api.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_child_process_async.rs
+++ b/crates/afterburner/tests/b_child_process_async.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_child_process_wasm.rs
+++ b/crates/afterburner/tests/b_child_process_wasm.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_cli_parity.rs
+++ b/crates/afterburner/tests/b_cli_parity.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_cluster_multiproc.rs
+++ b/crates/afterburner/tests/b_cluster_multiproc.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_columnar_udf.rs
+++ b/crates/afterburner/tests/b_columnar_udf.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_crypto_extras.rs
+++ b/crates/afterburner/tests/b_crypto_extras.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_crypto_extras_round5.rs
+++ b/crates/afterburner/tests/b_crypto_extras_round5.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_crypto_random_extras.rs
+++ b/crates/afterburner/tests/b_crypto_random_extras.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_crypto_stream_extras.rs
+++ b/crates/afterburner/tests/b_crypto_stream_extras.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_daemon_init_bytecode.rs
+++ b/crates/afterburner/tests/b_daemon_init_bytecode.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_debugger_breakpoint.rs
+++ b/crates/afterburner/tests/b_debugger_breakpoint.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_dns_resolveany_execfilesync.rs
+++ b/crates/afterburner/tests/b_dns_resolveany_execfilesync.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_events_add_abort_listener.rs
+++ b/crates/afterburner/tests/b_events_add_abort_listener.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_events_buffer_stream_extras.rs
+++ b/crates/afterburner/tests/b_events_buffer_stream_extras.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_eventsource.rs
+++ b/crates/afterburner/tests/b_eventsource.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_fetch_extras.rs
+++ b/crates/afterburner/tests/b_fetch_extras.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_filereader_sqlite_constants.rs
+++ b/crates/afterburner/tests/b_filereader_sqlite_constants.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_fs_classes.rs
+++ b/crates/afterburner/tests/b_fs_classes.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_fs_promises_expansion.rs
+++ b/crates/afterburner/tests/b_fs_promises_expansion.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_http2_client.rs
+++ b/crates/afterburner/tests/b_http2_client.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_http2_server.rs
+++ b/crates/afterburner/tests/b_http2_server.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_http3_quic.rs
+++ b/crates/afterburner/tests/b_http3_quic.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_http_header_validators.rs
+++ b/crates/afterburner/tests/b_http_header_validators.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_inspector_cdp.rs
+++ b/crates/afterburner/tests/b_inspector_cdp.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_intl_and_clone.rs
+++ b/crates/afterburner/tests/b_intl_and_clone.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_iterator_helpers.rs
+++ b/crates/afterburner/tests/b_iterator_helpers.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_json_rawjson_readline.rs
+++ b/crates/afterburner/tests/b_json_rawjson_readline.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_module_internals.rs
+++ b/crates/afterburner/tests/b_module_internals.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_node26_extras.rs
+++ b/crates/afterburner/tests/b_node26_extras.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_node26_surface.rs
+++ b/crates/afterburner/tests/b_node26_surface.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_node_compat_round2.rs
+++ b/crates/afterburner/tests/b_node_compat_round2.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_node_compat_round3.rs
+++ b/crates/afterburner/tests/b_node_compat_round3.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_node_surface_round4.rs
+++ b/crates/afterburner/tests/b_node_surface_round4.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_node_test_runner.rs
+++ b/crates/afterburner/tests/b_node_test_runner.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_npm_install_e2e.rs
+++ b/crates/afterburner/tests/b_npm_install_e2e.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_npm_prereqs.rs
+++ b/crates/afterburner/tests/b_npm_prereqs.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_os_dirs.rs
+++ b/crates/afterburner/tests/b_os_dirs.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_os_timers_extras.rs
+++ b/crates/afterburner/tests/b_os_timers_extras.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_performance_observer.rs
+++ b/crates/afterburner/tests/b_performance_observer.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_performance_user_timing.rs
+++ b/crates/afterburner/tests/b_performance_user_timing.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_pkg_dev.rs
+++ b/crates/afterburner/tests/b_pkg_dev.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_process_getters.rs
+++ b/crates/afterburner/tests/b_process_getters.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_process_lifecycle.rs
+++ b/crates/afterburner/tests/b_process_lifecycle.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_process_report.rs
+++ b/crates/afterburner/tests/b_process_report.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_process_stdio.rs
+++ b/crates/afterburner/tests/b_process_stdio.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_random_bytes_inspect_custom.rs
+++ b/crates/afterburner/tests/b_random_bytes_inspect_custom.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_raw_input.rs
+++ b/crates/afterburner/tests/b_raw_input.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_raw_output.rs
+++ b/crates/afterburner/tests/b_raw_output.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_request_fields.rs
+++ b/crates/afterburner/tests/b_request_fields.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_request_response_bytes_crypto_globals.rs
+++ b/crates/afterburner/tests/b_request_response_bytes_crypto_globals.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_require_denial.rs
+++ b/crates/afterburner/tests/b_require_denial.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_scheduler_dispose_stack.rs
+++ b/crates/afterburner/tests/b_scheduler_dispose_stack.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_script_exit_codes.rs
+++ b/crates/afterburner/tests/b_script_exit_codes.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_shadow_argon2.rs
+++ b/crates/afterburner/tests/b_shadow_argon2.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_shadow_bcrypt.rs
+++ b/crates/afterburner/tests/b_shadow_bcrypt.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_shadow_jsonwebtoken.rs
+++ b/crates/afterburner/tests/b_shadow_jsonwebtoken.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_shadow_sharp.rs
+++ b/crates/afterburner/tests/b_shadow_sharp.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_shadow_sqlite3.rs
+++ b/crates/afterburner/tests/b_shadow_sqlite3.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_shard_pool.rs
+++ b/crates/afterburner/tests/b_shard_pool.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_shebang.rs
+++ b/crates/afterburner/tests/b_shebang.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_sourcemaps.rs
+++ b/crates/afterburner/tests/b_sourcemaps.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_stream_dual_shape.rs
+++ b/crates/afterburner/tests/b_stream_dual_shape.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_stream_static_probes.rs
+++ b/crates/afterburner/tests/b_stream_static_probes.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_subtle_crypto.rs
+++ b/crates/afterburner/tests/b_subtle_crypto.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_subtle_full.rs
+++ b/crates/afterburner/tests/b_subtle_full.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_symbol_dispose.rs
+++ b/crates/afterburner/tests/b_symbol_dispose.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_tls_check_server_identity.rs
+++ b/crates/afterburner/tests/b_tls_check_server_identity.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_tls_defaults.rs
+++ b/crates/afterburner/tests/b_tls_defaults.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_uint8array_codec.rs
+++ b/crates/afterburner/tests/b_uint8array_codec.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_util_system_errors_callsites_diff.rs
+++ b/crates/afterburner/tests/b_util_system_errors_callsites_diff.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_v8_serialize_compat.rs
+++ b/crates/afterburner/tests/b_v8_serialize_compat.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_vm_measure_worker_untransferable.rs
+++ b/crates/afterburner/tests/b_vm_measure_worker_untransferable.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_vm_module_cycles.rs
+++ b/crates/afterburner/tests/b_vm_module_cycles.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_vm_module_records.rs
+++ b/crates/afterburner/tests/b_vm_module_records.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_wasm_extras.rs
+++ b/crates/afterburner/tests/b_wasm_extras.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_wasm_loader.rs
+++ b/crates/afterburner/tests/b_wasm_loader.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_wasm_memory_grow.rs
+++ b/crates/afterburner/tests/b_wasm_memory_grow.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_web_globals.rs
+++ b/crates/afterburner/tests/b_web_globals.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_web_streams.rs
+++ b/crates/afterburner/tests/b_web_streams.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_websocket.rs
+++ b/crates/afterburner/tests/b_websocket.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_zlib_brotli.rs
+++ b/crates/afterburner/tests/b_zlib_brotli.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_zlib_process_fs_extras.rs
+++ b/crates/afterburner/tests/b_zlib_process_fs_extras.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/b_zlib_streaming.rs
+++ b/crates/afterburner/tests/b_zlib_streaming.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/basic_eval.rs
+++ b/crates/afterburner/tests/basic_eval.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/cli_manifold.rs
+++ b/crates/afterburner/tests/cli_manifold.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/common/mod.rs
+++ b/crates/afterburner/tests/common/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 

--- a/crates/afterburner/tests/data_flow.rs
+++ b/crates/afterburner/tests/data_flow.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-// Copyright (c) 2026 Psila.AI
+// Copyright (c) 2026 vertexclique
 // Licensed under the Business Source License 1.1.
 // Change Date: 4 years after this version's release. Change License: Apache-2.0.
 


### PR DESCRIPTION
All contact emails become info@afterburner.sh; BSL licensor, NOTICE/TRADEMARK/CLA holder, and the 277 source headers now credit vertexclique.